### PR TITLE
Enable custom interactive parameters.

### DIFF
--- a/rootdir/etc/init.power.mofd_v1.rc
+++ b/rootdir/etc/init.power.mofd_v1.rc
@@ -1,6 +1,7 @@
 on property:sys.boot_completed=1
     # Set the I/O scheduler
     setprop sys.io.scheduler bfq
+    
     write /sys/devices/system/cpu/cpu1/online 1
     write /sys/devices/system/cpu/cpu2/online 1
     write /sys/devices/system/cpu/cpu3/online 1
@@ -13,6 +14,13 @@ on property:sys.boot_completed=1
     write /sys/devices/system/cpu/cpu2/cpufreq/scaling_max_freq ${ro.sys.perf.device.full}
     write /sys/devices/system/cpu/cpu3/cpufreq/scaling_max_freq ${ro.sys.perf.device.full}
     write /sys/devices/system/cpu/cpufreq/interactive/hispeed_freq 1083000
+    write /sys/devices/system/cpu/cpufreq/interactive/above_hispeed_delay 0
+    write /sys/devices/system/cpu/cpufreq/interactive/go_hispeed_load 50
+    write /sys/devices/system/cpu/cpufreq/interactive/min_sample_time 40000
+    write /sys/devices/system/cpu/cpufreq/interactive/target_loads "85 1500000:90 1800000:70"
+    write /sys/devices/system/cpu/cpufreq/interactive/timer_rate 30000
+    write /sys/devices/system/cpu/cpufreq/interactive/timer_slack 30000
+    write /sys/devices/system/cpu/cpufreq/interactive/touchboostpulse_duration 20000
     write /sys/devices/system/cpu/cpufreq/interactive/touchboost_freq ${ro.sys.perf.device.touchboost}
     setprop sys.perf.profile.governor interactive
     write /sys/devices/platform/dfrgx/devfreq/dfrgx/governor simple_ondemand


### PR DESCRIPTION
These were deleted by Crpalmer when he fixed the profile system. Now, they will apply after the device boots. However, they will not persist after a governor change.
